### PR TITLE
bug fix for issue#22413

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -2,6 +2,7 @@
 #          Manoj Kumar
 # License: BSD 3 clause
 
+import difflib
 import numpy as np
 
 
@@ -58,9 +59,18 @@ def compute_class_weight(class_weight, *, classes, y):
             raise ValueError(
                 "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
             )
-        for c in class_weight:
+        for c in classes:
             i = np.searchsorted(classes, c)
-            if i >= len(classes) or classes[i] != c:
+            if i >= len(classes) or c not in class_weight:
+                # # Get possible suggestion
+                if isinstance(c, str):
+                    suggestion = difflib.get_close_matches(c, class_weight.keys(), 1)[0]
+                    raise ValueError(
+                        "Class label {} not present.".format(c)
+                        + " Did you mean "
+                        + suggestion
+                        + "?"
+                    )
                 raise ValueError("Class label {} not present.".format(c))
             else:
                 weight[i] = class_weight[c]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
From the comments under issue https://github.com/scikit-learn/scikit-learn/pull/22413, the suggested fix has been to ensure that the classes passed or the values of the variable y in the fit() method should only contain class labels that have been mentioned in the class weight during the initialization of an estimator.

The current behavior performs the opposite which has been addressed in this fix.


#### Any other comments?
Our fix provides additional help to users in case the class labels are in the form of strings. If a user gives a wrong class in y, the code will raise an error along with a reference to the closest correct class from class_weight.

This was done to address the following concern as mentioned in the comment section as follows:

<img width="830" alt="Screen Shot 2022-03-04 at 12 39 41 AM" src="https://user-images.githubusercontent.com/50001661/156706219-c6ef2faa-af8a-430f-8830-58a7fe5544e3.png">

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
